### PR TITLE
Update canvasProp types to allow object values

### DIFF
--- a/src/SignaturePad.tsx
+++ b/src/SignaturePad.tsx
@@ -6,7 +6,7 @@ type Props = {
     width?: number;
     height?: number;
     options?: Options;
-    canvasProps?: { [key: string]: string };
+    canvasProps?: { [key: string]: string | { [key: string]: string } };
 } & DefaultProps;
 
 type DefaultProps = {


### PR DESCRIPTION
My use case requires the canvas to fully extend to the height of its container. To do so, I need to pass in a style as `canvasProps`:
```js
<SignaturePad
  // @ts-ignore
  canvasProps={{ style: { height: "100%" } }}
  redrawOnResize
  ref={signaturePadRef}
/>
```
This change will allow modifications to canvas style without using `ts-ignore`