### PR TITLE
Let rollup typescript plugin properly generate type declaration files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-__tests__
-example
-src
-.eslintignore
-.eslintrc.json
-.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -2961,9 +2961,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001296",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-      "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3534,9 +3534,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.36",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.36.tgz",
-      "integrity": "sha512-MbLlbF39vKrXWlFEFpCgDHwdlz4O3LmHM5W4tiLRHjSmEUXjJjz8sZkMgWgvYxlZw3N1iDTmCEtOkkESb5TMCg==",
+      "version": "1.4.38",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.38.tgz",
+      "integrity": "sha512-WhHt3sZazKj0KK/UpgsbGQnUUoFeAHVishzHFExMxagpZgjiGYSC9S0ZlbhCfSH2L2i+2A1yyqOIliTctMx7KQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4400,9 +4400,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.9.tgz",
+      "integrity": "sha512-MBwILhhD92sziIrMQwpqcuGERF+BH99ei2a3XsGJuqEKcSycAL+w0HWokFenZXona+kjFr82Lf71eTxNRC06XQ==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4412,7 +4412,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
@@ -4757,16 +4757,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -7489,9 +7489,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.5.tgz",
-      "integrity": "sha512-WyKb+0sNKDTd1LwwAfTBPp0XmdaKkAOEbg4oHE4Kq2+oQVchg/VAcjVQtSqZih1izNsTURjc2EkhG/syRQUXdA==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.7.tgz",
+      "integrity": "sha512-bltv/ejiLWtowExpjU+s5z8j1Byjg9AlmaAjMmqNbIicY69u6sYIwXGg0dCn0TlkrrY2CphtHIXAkbZ+1VoWQQ==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^3.1.0",
@@ -9169,9 +9169,9 @@
       "dev": true
     },
     "node_modules/signature_pad": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.0.tgz",
-      "integrity": "sha512-47I2MULJIHaUAFuVbqMVWwZR+GEl2wH4QKg16OwpQg82GzVUL3Z405Um6sLgVB0xbP5rwqiNzfLTbJwipXvaWA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.1.tgz",
+      "integrity": "sha512-VoXBsoQRXNPHj+bTyufvQCWmOaccfvEy9w91zrtHmi2dSW4vmf3LqXL64z8a1NCcUBtOrcA3iRuOYKyjgc8iDQ=="
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -12644,9 +12644,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001296",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-      "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
       "dev": true
     },
     "canvas": {
@@ -13087,9 +13087,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.36",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.36.tgz",
-      "integrity": "sha512-MbLlbF39vKrXWlFEFpCgDHwdlz4O3LmHM5W4tiLRHjSmEUXjJjz8sZkMgWgvYxlZw3N1iDTmCEtOkkESb5TMCg==",
+      "version": "1.4.38",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.38.tgz",
+      "integrity": "sha512-WhHt3sZazKj0KK/UpgsbGQnUUoFeAHVishzHFExMxagpZgjiGYSC9S0ZlbhCfSH2L2i+2A1yyqOIliTctMx7KQ==",
       "dev": true
     },
     "emittery": {
@@ -13729,9 +13729,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.9.tgz",
+      "integrity": "sha512-MBwILhhD92sziIrMQwpqcuGERF+BH99ei2a3XsGJuqEKcSycAL+w0HWokFenZXona+kjFr82Lf71eTxNRC06XQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -14005,16 +14005,16 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
     },
@@ -16017,9 +16017,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.5.tgz",
-      "integrity": "sha512-WyKb+0sNKDTd1LwwAfTBPp0XmdaKkAOEbg4oHE4Kq2+oQVchg/VAcjVQtSqZih1izNsTURjc2EkhG/syRQUXdA==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.7.tgz",
+      "integrity": "sha512-bltv/ejiLWtowExpjU+s5z8j1Byjg9AlmaAjMmqNbIicY69u6sYIwXGg0dCn0TlkrrY2CphtHIXAkbZ+1VoWQQ==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",
@@ -17286,9 +17286,9 @@
       "dev": true
     },
     "signature_pad": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.0.tgz",
-      "integrity": "sha512-47I2MULJIHaUAFuVbqMVWwZR+GEl2wH4QKg16OwpQg82GzVUL3Z405Um6sLgVB0xbP5rwqiNzfLTbJwipXvaWA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.1.tgz",
+      "integrity": "sha512-VoXBsoQRXNPHj+bTyufvQCWmOaccfvEy9w91zrtHmi2dSW4vmf3LqXL64z8a1NCcUBtOrcA3iRuOYKyjgc8iDQ=="
     },
     "simple-concat": {
       "version": "1.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,8 +11,19 @@ const local = process.env.NODE_ENV === 'local';
 export default {
     input: 'src/index.ts',
     output: [
-        { file: pkg.main, format: 'cjs', sourcemap: local, exports: 'named' },
-        { file: pkg.module, format: 'es', sourcemap: local },
+        {
+            dir: './',
+            entryFileNames: pkg.main,
+            format: 'cjs',
+            sourcemap: local,
+            exports: 'named',
+        },
+        {
+            dir: './',
+            entryFileNames: pkg.module,
+            format: 'es',
+            sourcemap: local,
+        },
     ],
     external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
     watch: {
@@ -23,6 +34,9 @@ export default {
         typescript({
             typescript: require('typescript'),
             sourceMap: local,
+            declaration: true,
+            declarationDir: 'dist/',
+            rootDir: 'src/',
         }),
         commonjs(),
         nodeResolve(),

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "strict": true,
     "declaration": true,
     "declarationDir": "./dist",
+    "rootDir": "./src",
     "outDir": "./dist",
     "jsx": "react"
   },


### PR DESCRIPTION
Closes #39 

The official rollup TypeScript plugin does not automatically generate type declaration files. Using [this](https://github.com/rollup/plugins/issues/61#issuecomment-597090769) workaround they are generated again.