### PR TITLE
Stay empty after redraw if was empty

### DIFF
--- a/__tests__/SignaturePad.test.tsx
+++ b/__tests__/SignaturePad.test.tsx
@@ -217,6 +217,9 @@ describe('Component', () => {
             render(<SignaturePad ref={instance} redrawOnResize />);
 
             const signaturePad = instance.current as SignaturePad;
+
+            signaturePad.fromDataURL(signature);
+
             const spy = jest.spyOn(signaturePad.instance, 'toDataURL');
 
             scaleCanvas(768, 768);
@@ -233,11 +236,28 @@ describe('Component', () => {
             render(<SignaturePad ref={instance} redrawOnResize />);
 
             const signaturePad = instance.current as SignaturePad;
+
+            signaturePad.fromDataURL(signature);
+
             const spy = jest.spyOn(signaturePad.instance, 'toDataURL');
 
             signaturePad.handleResize();
 
             expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('is empty after redraw if was empty', () => {
+            const instance = React.createRef<SignaturePad>();
+
+            render(<SignaturePad ref={instance} redrawOnResize />);
+
+            const signaturePad = instance.current as SignaturePad;
+
+            expect(signaturePad.isEmpty()).toBeTruthy();
+
+            scaleCanvas(768, 768);
+
+            expect(signaturePad.isEmpty()).toBeTruthy();
         });
 
         it('does not add the resize event listener on mount', () => {

--- a/__tests__/SignaturePad.test.tsx
+++ b/__tests__/SignaturePad.test.tsx
@@ -246,7 +246,7 @@ describe('Component', () => {
             expect(spy).not.toHaveBeenCalled();
         });
 
-        it('is empty after redraw if was empty', () => {
+        it('does not redraw a signature when the canvas is empty', () => {
             const instance = React.createRef<SignaturePad>();
 
             render(<SignaturePad ref={instance} redrawOnResize />);

--- a/src/SignaturePad.tsx
+++ b/src/SignaturePad.tsx
@@ -358,7 +358,7 @@ class SignaturePad extends React.PureComponent<Props, State> {
         let data;
 
         if (this.props.redrawOnResize && this.signaturePad) {
-            data = this.signaturePad.toDataURL();
+            data = !this.signaturePad.isEmpty() && this.signaturePad.toDataURL();
         }
 
         canvas.width = width;

--- a/src/SignaturePad.tsx
+++ b/src/SignaturePad.tsx
@@ -358,7 +358,7 @@ class SignaturePad extends React.PureComponent<Props, State> {
         let data;
 
         if (this.props.redrawOnResize && this.signaturePad && !this.signaturePad.isEmpty()) {
-            data = !this.signaturePad.isEmpty() && this.signaturePad.toDataURL();
+            data = this.signaturePad.toDataURL();
         }
 
         canvas.width = width;

--- a/src/SignaturePad.tsx
+++ b/src/SignaturePad.tsx
@@ -357,7 +357,7 @@ class SignaturePad extends React.PureComponent<Props, State> {
 
         let data;
 
-        if (this.props.redrawOnResize && this.signaturePad) {
+        if (this.props.redrawOnResize && this.signaturePad && !this.signaturePad.isEmpty()) {
             data = !this.signaturePad.isEmpty() && this.signaturePad.toDataURL();
         }
 


### PR DESCRIPTION
Hello, 

`isEmpty()` behaved not as expected after a redraw happened.
This fixes it. `isEmpty()` is now still true after a redraw, if it was before true.
