### PR TITLE
Bump signature_pad dependancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.1",
-        "signature_pad": "^5.0.1",
+        "signature_pad": "^5.1.0",
         "throttle-debounce": "^5.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "prop-types": "^15.8.1",
-    "signature_pad": "^5.0.1",
+    "signature_pad": "^5.1.0",
     "throttle-debounce": "^5.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
`signature_pad` 5.1.x is needed because of the `redraw` method.